### PR TITLE
fix: replace TikTok PNG icons with SVG for consistent styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -240,7 +240,7 @@
                 </p>
                 <div class="flex justify-center items-center flex-wrap gap-4">
                     <a href="https://www.tiktok.com/@wanderjapan.co" target="_blank" rel="noopener noreferrer" class="bg-fuchsia-200 text-fuchsia-800 font-bold py-3 px-6 rounded-full hover:bg-white hover:text-fuchsia-700 transition-all duration-300 inline-flex items-center space-x-2.5 shadow-md">
-                        <img src="./tiktok-logo.png" alt="TikTok" class="h-6 w-6" />
+                        <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-.88-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-.04-.1z"/></svg>
                         <span>TikTok</span>
                     </a>
                     <a href="https://www.instagram.com/wanderjapan.co" target="_blank" rel="noopener noreferrer" class="bg-fuchsia-200 text-fuchsia-800 font-bold py-3 px-6 rounded-full hover:bg-white hover:text-fuchsia-700 transition-all duration-300 inline-flex items-center space-x-2.5 shadow-md">
@@ -273,8 +273,8 @@
             </div>
 
             <div class="flex justify-center space-x-6 mb-8">
-                 <a href="https://www.tiktok.com/@wanderjapan.co" target="_blank" rel="noopener noreferrer" class="hover:opacity-75 transition-opacity" aria-label="TikTok">
-                    <img src="./tiktok-footer-logo.png" alt="TikTok" class="h-6 w-6" />
+                 <a href="https://www.tiktok.com/@wanderjapan.co" target="_blank" rel="noopener noreferrer" class="hover:text-white transition-colors" aria-label="TikTok">
+                    <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-.88-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-.04-.1z"/></svg>
                  </a>
                  <a href="https://www.instagram.com/wanderjapan.co" target="_blank" rel="noopener noreferrer" class="hover:text-white transition-colors" aria-label="Instagram">
                     <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.85s-.011 3.585-.069 4.85c-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.85-.07-3.252-.148-4.771-1.691-4.919-4.919-.058-1.265-.069-1.645-.069-4.85s.011-3.585.069-4.85c.149-3.225 1.664-4.771 4.919-4.919C8.356 2.175 8.74 2.163 12 2.163m0-2.163C8.74 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.74 0 12s.014 3.667.072 4.947c.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.74 24 12 24s3.667-.014 4.947-.072c4.358-.2 6.78-2.618 6.98-6.98C23.986 15.667 24 15.26 24 12s-.014-3.667-.072-4.947c-.2-4.358-2.618-6.78-6.98-6.98C15.667.014 15.26 0 12 0zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zM12 16a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 100 2.88 1.44 1.44 0 000-2.88z"></path></svg>


### PR DESCRIPTION
## Problem
TikTok icons were displaying in different colors than Instagram and YouTube icons because:
- TikTok used `<img>` tags with PNG files (fixed color)
- Instagram/YouTube used `<svg>` tags with `fill="currentColor"` (CSS controlled)

## Solution
- ✅ Replace `tiktok-logo.png` with SVG in social media section
- ✅ Replace `tiktok-footer-logo.png` with SVG in footer  
- ✅ Add `fill="currentColor"` to enable CSS color control
- ✅ Update footer TikTok link classes to match other social icons

## Result
All social media icons now consistently use:
- Same fuchsia-800 color in main section
- Same fuchsia-400 → white hover transitions in footer
- Unified CSS-controlled styling approach

## Before/After
**Before**: TikTok = PNG original colors, Instagram/YouTube = fuchsia-800  
**After**: All icons = fuchsia-800 with consistent hover effects

## Test Plan
- [x] Verify all social media icons display in same color
- [x] Test hover effects work consistently
- [x] Confirm responsive behavior maintained